### PR TITLE
build: fix import order when building with nix

### DIFF
--- a/build.py
+++ b/build.py
@@ -4,8 +4,8 @@ import os
 import shutil
 from pathlib import Path
 
-from Cython.Build import build_ext, cythonize
 from setuptools import Distribution, Extension
+from Cython.Build import build_ext, cythonize
 
 # import Cython.Compiler.Options
 # Cython.Compiler.Options.cimport_from_pyx = True

--- a/build.py
+++ b/build.py
@@ -4,6 +4,10 @@ import os
 import shutil
 from pathlib import Path
 
+# setuptools *must* come before Cython, otherwise Cython's distutils hacking
+# will override setuptools' build_ext command and cause problems in other build
+# systems such as nix.
+
 from setuptools import Distribution, Extension
 from Cython.Build import build_ext, cythonize
 

--- a/build.py
+++ b/build.py
@@ -7,9 +7,6 @@ from pathlib import Path
 from setuptools import Distribution, Extension
 from Cython.Build import build_ext, cythonize
 
-# import Cython.Compiler.Options
-# Cython.Compiler.Options.cimport_from_pyx = True
-
 SOURCE_DIR = Path("koerce")
 BUILD_DIR = Path("cython_build")
 

--- a/koerce/tests/test_patterns.py
+++ b/koerce/tests/test_patterns.py
@@ -206,15 +206,13 @@ def test_type_of(typ, value, expected):
         assert pattern.apply(value) is NoMatch
 
 
-class MyMeta(type):
-	...
+class MyMeta(type): ...
 
 
-class MyClass(metaclass=MyMeta):
-	...
+class MyClass(metaclass=MyMeta): ...
 
-class MyOtherClass:
-    ...
+
+class MyOtherClass: ...
 
 
 def test_type_of_with_metaclass():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ required-imports = ["from __future__ import annotations"]
     "E731",  # Do not assign a `lambda` expression, use a `def`
     "S301",  # pickle is allowed in tests
 ]
-"build.py" = ["I001"] # because of distutils hacking cython
+"build.py" = ["I001"] # because of distutils hacking happening in cython
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,7 @@ required-imports = ["from __future__ import annotations"]
     "E731",  # Do not assign a `lambda` expression, use a `def`
     "S301",  # pickle is allowed in tests
 ]
+"build.py" = ["I001"] # because of distutils hacking cython
 
 [tool.ruff.format]
 docstring-code-format = true


### PR DESCRIPTION
Cython hacks distutils which causes failures when depending on koerce in a nix environment.