### PR TITLE
fix(patterns): allow deferred and builder in `Capture` pattern

### DIFF
--- a/koerce/patterns.py
+++ b/koerce/patterns.py
@@ -1220,7 +1220,7 @@ class Capture(Pattern):
 
     """
 
-    key: str | Deferred | Builder
+    key: str
     what: Pattern
 
     def __init__(self, key: str | Deferred | Builder, what=_any):

--- a/koerce/patterns.py
+++ b/koerce/patterns.py
@@ -1220,10 +1220,10 @@ class Capture(Pattern):
 
     """
 
-    key: str
+    key: str | Deferred | Builder
     what: Pattern
 
-    def __init__(self, key, what=_any):
+    def __init__(self, key: str | Deferred | Builder, what=_any):
         if isinstance(key, (Deferred, Builder)):
             key = builder(key)
             if isinstance(key, Variable):

--- a/koerce/tests/test_patterns.py
+++ b/koerce/tests/test_patterns.py
@@ -520,6 +520,21 @@ def test_capture():
     assert ctx == {"result": 12}
 
 
+@pytest.mark.parametrize(
+    "x", [Deferred(Variable("x")), Variable("x")], ids=["deferred", "builder"]
+)
+def test_capture_with_deferred_and_builder(x):
+    ctx = {}
+
+    p = Capture(x, InstanceOf(float))
+
+    assert p.apply(1, context=ctx) is NoMatch
+    assert ctx == {}
+
+    assert p.apply(1.0, ctx) == 1.0
+    assert ctx == {"x": 1.0}
+
+
 def test_none_of():
     def negative(x):
         return x < 0


### PR DESCRIPTION
Accept `Deferred` and `Builder` in `Capture` instead of only accepting `str`.