### PR TITLE
feat: cythonize inspect signature

### DIFF
--- a/build.py
+++ b/build.py
@@ -25,6 +25,10 @@ cythonized_modules = cythonize(
             "koerce.patterns",
             ["koerce/patterns.py"],
         ),
+        Extension(
+            "koerce.utils",
+            ["koerce/utils.py"],
+        ),
     ],
     build_dir=BUILD_DIR,
     # generate anannotated .html output files.
@@ -41,7 +45,7 @@ cythonized_modules = cythonize(
         # "annotation_typing": False
     },
     # always rebuild, even if files untouched
-    force=True,
+    force=False,
     # emit_linenums=True
 )
 

--- a/koerce/sugar.py
+++ b/koerce/sugar.py
@@ -174,10 +174,9 @@ def annotated(_1=None, _2=None, _3=None, **kwargs):
     def wrapped(*args, **kwargs):
         # 0. Bind the arguments to the signature
         bound = sig.bind(*args, **kwargs)
-        bound.apply_defaults()
 
         # 1. Validate the passed arguments
-        values = argpats.apply(bound.arguments)
+        values = argpats.apply(bound)
         if values is NoMatch:
             raise ValidationError()
 

--- a/koerce/tests/test_sugar.py
+++ b/koerce/tests/test_sugar.py
@@ -39,11 +39,10 @@ def test_signature_unbind_from_callable():
 
     sig = Signature.from_callable(test)
     bound = sig.bind(2, 3)
-    bound.apply_defaults()
 
-    assert bound.arguments == {"a": 2, "b": 3, "c": 1}
+    assert bound == {"a": 2, "b": 3, "c": 1}
 
-    args, kwargs = sig.unbind(bound.arguments)
+    args, kwargs = sig.unbind(bound)
     assert args == (2, 3, 1)
     assert kwargs == {}
 
@@ -53,17 +52,15 @@ def test_signature_unbind_from_callable_with_varargs():
 
     sig = Signature.from_callable(test)
     bound = sig.bind(2, 3)
-    bound.apply_defaults()
 
-    assert bound.arguments == {"a": 2, "b": 3, "args": ()}
-    args, kwargs = sig.unbind(bound.arguments)
+    assert bound == {"a": 2, "b": 3, "args": ()}
+    args, kwargs = sig.unbind(bound)
     assert args == (2, 3)
     assert kwargs == {}
 
     bound = sig.bind(2, 3, 4, 5)
-    bound.apply_defaults()
-    assert bound.arguments == {"a": 2, "b": 3, "args": (4, 5)}
-    args, kwargs = sig.unbind(bound.arguments)
+    assert bound == {"a": 2, "b": 3, "args": (4, 5)}
+    args, kwargs = sig.unbind(bound)
     assert args == (2, 3, 4, 5)
     assert kwargs == {}
 
@@ -73,18 +70,16 @@ def test_signature_unbind_from_callable_with_positional_only_arguments():
 
     sig = Signature.from_callable(test)
     bound = sig.bind(2, 3)
-    bound.apply_defaults()
-    assert bound.arguments == {"a": 2, "b": 3, "c": 1}
+    assert bound == {"a": 2, "b": 3, "c": 1}
 
-    args, kwargs = sig.unbind(bound.arguments)
+    args, kwargs = sig.unbind(bound)
     assert args == (2, 3, 1)
     assert kwargs == {}
 
     bound = sig.bind(2, 3, 4)
-    bound.apply_defaults()
-    assert bound.arguments == {"a": 2, "b": 3, "c": 4}
+    assert bound == {"a": 2, "b": 3, "c": 4}
 
-    args, kwargs = sig.unbind(bound.arguments)
+    args, kwargs = sig.unbind(bound)
     assert args == (2, 3, 4)
     assert kwargs == {}
 
@@ -94,10 +89,9 @@ def test_signature_unbind_from_callable_with_keyword_only_arguments():
 
     sig = Signature.from_callable(test)
     bound = sig.bind(2, 3, c=4.0)
-    bound.apply_defaults()
-    assert bound.arguments == {"a": 2, "b": 3, "c": 4.0, "d": 0.0}
+    assert bound == {"a": 2, "b": 3, "c": 4.0, "d": 0.0}
 
-    args, kwargs = sig.unbind(bound.arguments)
+    args, kwargs = sig.unbind(bound)
     assert args == (2, 3)
     assert kwargs == {"c": 4.0, "d": 0.0}
 
@@ -107,11 +101,10 @@ def test_signature_unbind():
 
     sig = Signature.from_callable(func)
     bound = sig.bind(1, 2)
-    bound.apply_defaults()
 
-    assert bound.arguments == {"a": 1, "b": 2, "c": 1}
+    assert bound == {"a": 1, "b": 2, "c": 1}
 
-    args, kwargs = sig.unbind(bound.arguments)
+    args, kwargs = sig.unbind(bound)
     assert args == (1, 2, 1)
     assert kwargs == {}
 
@@ -123,10 +116,9 @@ def test_signature_unbind_with_empty_variadic(d):
 
     sig = Signature.from_callable(func)
     bound = sig.bind(1, 2, 3, *d, e=4)
-    bound.apply_defaults()
-    assert bound.arguments == {"a": 1, "b": 2, "c": 3, "args": d, "e": 4}
+    assert bound == {"a": 1, "b": 2, "c": 3, "args": d, "e": 4}
 
-    args, kwargs = sig.unbind(bound.arguments)
+    args, kwargs = sig.unbind(bound)
     assert args == (1, 2, 3, *d)
     assert kwargs == {"e": 4}
 
@@ -254,7 +246,7 @@ def test_annotated_function_without_annotations():
         return a, b, c
 
     assert test(1, 2, 3) == (1, 2, 3)
-    assert test.__signature__.parameters.keys() == {"a", "b", "c"}
+    assert [p.name for p in test.__signature__.parameters] == ["a", "b", "c"]
 
 
 # def test_annotated_function_without_decoration(snapshot):

--- a/koerce/tests/test_utils.py
+++ b/koerce/tests/test_utils.py
@@ -4,7 +4,14 @@ from typing import Dict, Generic, List, Optional, TypeVar
 
 import pytest
 
-from koerce.utils import get_type_boundvars, get_type_hints, get_type_params
+from koerce.utils import (
+    EMPTY,
+    Parameter,
+    Signature,
+    get_type_boundvars,
+    get_type_hints,
+    get_type_params,
+)
 
 T = TypeVar("T", covariant=True)
 S = TypeVar("S", covariant=True)
@@ -108,3 +115,412 @@ def test_get_type_boundvars_unable_to_deduce() -> None:
     msg = "Unable to deduce corresponding type attributes..."
     with pytest.raises(ValueError, match=msg):
         get_type_boundvars(MyDict[int, str])
+
+
+def test_parameter():
+    p = Parameter("x", Parameter.POSITIONAL_OR_KEYWORD, annotation=int)
+    assert p.name == "x"
+    assert p.kind is Parameter.POSITIONAL_OR_KEYWORD
+    assert str(p) == "x: int"
+
+    p = Parameter("x", Parameter.POSITIONAL_OR_KEYWORD, default=1)
+    assert p.name == "x"
+    assert p.kind is Parameter.POSITIONAL_OR_KEYWORD
+    assert p.default_ == 1
+    assert str(p) == "x=1"
+
+    p = Parameter("x", Parameter.POSITIONAL_OR_KEYWORD, annotation=int, default=1)
+    assert p.name == "x"
+    assert p.kind is Parameter.POSITIONAL_OR_KEYWORD
+    assert p.default_ == 1
+    assert p.annotation is int
+    assert str(p) == "x: int = 1"
+
+    p = Parameter("y", Parameter.VAR_POSITIONAL, annotation=int)
+    assert p.name == "y"
+    assert p.kind is Parameter.VAR_POSITIONAL
+    assert p.annotation is int
+    assert str(p) == "*y: int"
+
+    p = Parameter("z", Parameter.VAR_KEYWORD, annotation=int)
+    assert p.name == "z"
+    assert p.kind is Parameter.VAR_KEYWORD
+    assert p.annotation is int
+    assert str(p) == "**z: int"
+
+
+def test_signature_contruction():
+    a = Parameter("a", Parameter.POSITIONAL_OR_KEYWORD, annotation=int)
+    b = Parameter("b", Parameter.POSITIONAL_OR_KEYWORD, annotation=str)
+    c = Parameter("c", Parameter.POSITIONAL_OR_KEYWORD, annotation=int, default=1)
+    d = Parameter("d", Parameter.VAR_POSITIONAL, annotation=int)
+
+    sig = Signature([a, b, c, d])
+    assert sig.parameters == [a, b, c, d]
+    assert sig.return_annotation is EMPTY
+
+
+def test_signature_from_callable():
+    def func(a: int, b: str, *args, c=1, **kwargs) -> float: ...
+
+    sig = Signature.from_callable(func)
+    assert sig.parameters == [
+        Parameter("a", Parameter.POSITIONAL_OR_KEYWORD, annotation="int"),
+        Parameter("b", Parameter.POSITIONAL_OR_KEYWORD, annotation="str"),
+        Parameter("args", Parameter.VAR_POSITIONAL),
+        Parameter("c", Parameter.KEYWORD_ONLY, default=1),
+        Parameter("kwargs", Parameter.VAR_KEYWORD),
+    ]
+    assert sig.return_annotation == "float"
+
+
+def test_signature_bind_various():
+    # with positional or keyword default
+    def func(a: int, b: str, c=1) -> float: ...
+
+    sig = Signature.from_callable(func)
+    bound = sig.bind(1, "2")
+    assert bound == {"a": 1, "b": "2", "c": 1}
+
+    # with variable positional arguments
+    def func(a: int, b: str, *args: int, c=1) -> float: ...
+
+    sig = Signature.from_callable(func)
+    bound = sig.bind(1, "2", 3, 4)
+    assert bound == {"a": 1, "b": "2", "args": (3, 4), "c": 1}
+
+    # with both variadic positional and variadic keyword arguments
+    def func(a: int, b: str, *args: int, c=1, **kwargs: int) -> float: ...
+
+    sig = Signature.from_callable(func)
+    bound = sig.bind(1, "2", 3, 4, x=5, y=6)
+    assert bound == {
+        "a": 1,
+        "b": "2",
+        "args": (3, 4),
+        "c": 1,
+        "kwargs": {"x": 5, "y": 6},
+    }
+
+    # with positional only arguments
+    def func(a: int, b: str, /, c=1) -> float: ...
+
+    sig = Signature.from_callable(func)
+    bound = sig.bind(1, "2")
+    assert bound == {"a": 1, "b": "2", "c": 1}
+
+    with pytest.raises(TypeError, match="passed as keyword argument"):
+        sig.bind(a=1, b="2", c=3)
+
+    # with keyword only arguments
+    def func(a: int, b: str, *, c=1) -> float: ...
+
+    sig = Signature.from_callable(func)
+    bound = sig.bind(1, "2", c=3)
+    assert bound == {"a": 1, "b": "2", "c": 3}
+
+    with pytest.raises(TypeError, match="too many positional arguments"):
+        sig.bind(1, "2", 3)
+
+    def func(a, *args, b, z=100, **kwargs): ...
+
+    sig = Signature.from_callable(func)
+    bound = sig.bind(10, 20, b=30, c=40, args=50, kwargs=60)
+    assert bound == {
+        "a": 10,
+        "args": (20,),
+        "b": 30,
+        "z": 100,
+        "kwargs": {"c": 40, "args": 50, "kwargs": 60},
+    }
+
+
+def call(func, *args, **kwargs):
+    # it also tests the unbind method
+    sig = Signature.from_callable(func)
+    bound = sig.bind(*args, **kwargs)
+    ubargs, ubkwargs = sig.unbind(bound)
+    return func(*ubargs, **ubkwargs)
+
+
+def test_signature_bind_no_arguments():
+    def func(): ...
+
+    sig = Signature.from_callable(func)
+    assert sig.bind() == {}
+
+    with pytest.raises(TypeError, match="too many positional arguments"):
+        sig.bind(1)
+    with pytest.raises(TypeError, match="too many positional arguments"):
+        sig.bind(1, keyword=2)
+    with pytest.raises(TypeError, match="got an unexpected keyword argument 'keyword'"):
+        sig.bind(keyword=1)
+
+
+def test_signature_bind_positional_or_keyword_arguments():
+    def func(a, b, c):
+        return a, b, c
+
+    with pytest.raises(TypeError, match="missing a required argument: 'a'"):
+        call(func)
+    with pytest.raises(TypeError, match="missing a required argument: 'b'"):
+        call(func, 1)
+    with pytest.raises(TypeError, match="missing a required argument: 'c'"):
+        call(func, 1, 2)
+    assert call(func, 1, 2, 3) == (1, 2, 3)
+
+    # one optional argument
+    def func(a, b, c=0):
+        return a, b, c
+
+    assert call(func, 1, 2, 3) == (1, 2, 3)
+    assert call(func, 1, 2) == (1, 2, 0)
+
+    # two optional arguments
+    def func(a, b=0, c=0):
+        return a, b, c
+
+    assert call(func, 1, 2, 3) == (1, 2, 3)
+    assert call(func, 1, 2) == (1, 2, 0)
+    assert call(func, 1) == (1, 0, 0)
+
+    # three optional arguments
+    def func(a=0, b=0, c=0):
+        return a, b, c
+
+    assert call(func, 1, 2, 3) == (1, 2, 3)
+    assert call(func, 1, 2) == (1, 2, 0)
+    assert call(func, 1) == (1, 0, 0)
+    assert call(func) == (0, 0, 0)
+
+
+def test_signature_bind_varargs():
+    def func(*args):
+        return args
+
+    assert call(func) == ()
+    assert call(func, 1) == (1,)
+    assert call(func, 1, 2) == (1, 2)
+    assert call(func, 1, 2, 3) == (1, 2, 3)
+
+    def func(a, b, c=3, *args):
+        return a, b, c, args
+
+    assert call(func, 1, 2) == (1, 2, 3, ())
+    assert call(func, 1, 2, 3) == (1, 2, 3, ())
+    assert call(func, 1, 2, 3, 4) == (1, 2, 3, (4,))
+    assert call(func, 1, 2, 3, 4, 5) == (1, 2, 3, (4, 5))
+    assert call(func, 1, 2, 4) == (1, 2, 4, ())
+    assert call(func, a=1, b=2, c=3) == (1, 2, 3, ())
+    assert call(func, c=3, a=1, b=2) == (1, 2, 3, ())
+
+    with pytest.raises(TypeError, match="multiple values for argument 'c'"):
+        call(func, 1, 2, 3, c=4)
+
+    def func(a, *args):
+        return a, args
+
+    with pytest.raises(TypeError, match="got an unexpected keyword argument 'args'"):
+        call(func, a=0, args=1)
+
+    def func(*args, **kwargs):
+        return args, kwargs
+
+    assert call(func, args=1) == ((), {"args": 1})
+
+    sig = Signature.from_callable(func)
+    ba = sig.bind(args=1)
+    assert ba == {"args": (), "kwargs": {"args": 1}}
+
+
+def test_signature_bind_varkwargs():
+    def func(**kwargs):
+        return kwargs
+
+    assert call(func) == {}
+    assert call(func, foo="bar") == {"foo": "bar"}
+    assert call(func, foo="bar", spam="ham") == {"foo": "bar", "spam": "ham"}
+
+    def func(a, b, c=3, **kwargs):
+        return a, b, c, kwargs
+
+    assert call(func, 1, 2) == (1, 2, 3, {})
+    assert call(func, 1, 2, foo="bar") == (1, 2, 3, {"foo": "bar"})
+    assert call(func, 1, 2, foo="bar", spam="ham") == (
+        1,
+        2,
+        3,
+        {"foo": "bar", "spam": "ham"},
+    )
+    assert call(func, 1, 2, foo="bar", spam="ham", c=4) == (
+        1,
+        2,
+        4,
+        {"foo": "bar", "spam": "ham"},
+    )
+    assert call(func, 1, 2, c=4, foo="bar", spam="ham") == (
+        1,
+        2,
+        4,
+        {"foo": "bar", "spam": "ham"},
+    )
+    assert call(func, 1, 2, c=4, foo="bar", spam="ham", args=10) == (
+        1,
+        2,
+        4,
+        {"foo": "bar", "spam": "ham", "args": 10},
+    )
+    assert call(func, b=2, a=1, c=4, foo="bar", spam="ham") == (
+        1,
+        2,
+        4,
+        {"foo": "bar", "spam": "ham"},
+    )
+
+
+def test_signature_bind_varargs_and_varkwargs():
+    def func(*args, **kwargs):
+        return args, kwargs
+
+    assert call(func) == ((), {})
+    assert call(func, 1) == ((1,), {})
+    assert call(func, 1, 2) == ((1, 2), {})
+    assert call(func, foo="bar") == ((), {"foo": "bar"})
+    assert call(func, 1, foo="bar") == ((1,), {"foo": "bar"})
+    assert call(func, args=10), () == {"args": 10}
+    assert call(func, 1, 2, foo="bar") == ((1, 2), {"foo": "bar"})
+    assert call(func, 1, 2, foo="bar", spam="ham") == (
+        (1, 2),
+        {"foo": "bar", "spam": "ham"},
+    )
+    assert call(func, foo="bar", spam="ham", args=10) == (
+        (),
+        {"foo": "bar", "spam": "ham", "args": 10},
+    )
+
+
+def test_signature_bind_positional_only_arguments():
+    def func(a, b, /, c=3):
+        return a, b, c
+
+    assert call(func, 1, 2) == (1, 2, 3)
+    assert call(func, 1, 2, 4) == (1, 2, 4)
+    assert call(func, 1, 2, c=4) == (1, 2, 4)
+    with pytest.raises(TypeError, match="multiple values for argument 'c'"):
+        call(func, 1, 2, 3, c=4)
+
+    def func(a, b=2, /, c=3, *args):
+        return a, b, c, args
+
+    assert call(func, 1, 2) == (1, 2, 3, ())
+    assert call(func, 1, 2, 4) == (1, 2, 4, ())
+    assert call(func, 1, c=3) == (1, 2, 3, ())
+
+    def func(a, b, c=3, /, foo=42, *, bar=50, **kwargs):
+        return a, b, c, foo, bar, kwargs
+
+    assert call(func, 1, 2, 4, 5, bar=6) == (1, 2, 4, 5, 6, {})
+    assert call(func, 1, 2) == (1, 2, 3, 42, 50, {})
+    assert call(func, 1, 2, foo=4, bar=5) == (1, 2, 3, 4, 5, {})
+    assert call(func, 1, 2, foo=4, bar=5, c=10) == (1, 2, 3, 4, 5, {"c": 10})
+    assert call(func, 1, 2, 30, c=31, foo=4, bar=5) == (1, 2, 30, 4, 5, {"c": 31})
+    assert call(func, 1, 2, 30, foo=4, bar=5, c=31) == (1, 2, 30, 4, 5, {"c": 31})
+    assert call(func, 1, 2, c=4) == (1, 2, 3, 42, 50, {"c": 4})
+    assert call(func, 1, 2, c=4, foo=5) == (1, 2, 3, 5, 50, {"c": 4})
+
+    with pytest.raises(
+        TypeError, match="positional only argument 'a' passed as keyword argument"
+    ):
+        call(func, a=1, b=2)
+
+    def func(a=1, b=2, /):
+        return a, b
+
+    with pytest.raises(TypeError, match="got an unexpected keyword argument 'a'"):
+        call(func, a=3, b=4)
+
+    def func(a, /, **kwargs):
+        return a, kwargs
+
+    assert call(func, "pos-only", bar="keyword") == ("pos-only", {"bar": "keyword"})
+
+
+def test_signature_bind_keyword_only_arguments():
+    def func(*, a, b, c=3):
+        return a, b, c
+
+    with pytest.raises(TypeError, match="too many positional arguments"):
+        call(func, 1)
+
+    assert call(func, a=1, b=2) == (1, 2, 3)
+    assert call(func, a=1, b=2, c=4) == (1, 2, 4)
+
+    def func(a, *, b, c=3, **kwargs):
+        return a, b, c, kwargs
+
+    with pytest.raises(TypeError, match="missing a required argument: 'b'"):
+        call(func, 1)
+
+    assert call(func, 1, b=2) == (1, 2, 3, {})
+    assert call(func, 1, b=2, c=4) == (1, 2, 4, {})
+
+    def func(*, a, b, c=3, foo=42, **kwargs):
+        return a, b, c, foo, kwargs
+
+    assert call(func, a=1, b=2) == (1, 2, 3, 42, {})
+    assert call(func, a=1, b=2, foo=4) == (1, 2, 3, 4, {})
+    assert call(func, a=1, b=2, foo=4, bar=5) == (1, 2, 3, 4, {"bar": 5})
+    assert call(func, a=1, b=2, foo=4, bar=5, c=10) == (1, 2, 10, 4, {"bar": 5})
+    assert call(func, a=1, b=2, foo=4, bar=5, c=10, spam=6) == (
+        1,
+        2,
+        10,
+        4,
+        {"bar": 5, "spam": 6},
+    )
+
+    with pytest.raises(TypeError, match="missing a required argument: 'a'"):
+        call(func, b=2)
+    with pytest.raises(TypeError, match="missing a required argument: 'b'"):
+        call(func, a=1)
+
+    def func(a, *, b):
+        return a, b
+
+    assert call(func, 1, b=2) == (1, 2)
+    with pytest.raises(TypeError, match="missing a required argument: 'b'"):
+        call(func, 1)
+    with pytest.raises(TypeError, match="missing a required argument: 'a'"):
+        call(func, b=2)
+    with pytest.raises(TypeError, match="got an unexpected keyword argument 'c'"):
+        call(func, a=1, b=2, c=3)
+    with pytest.raises(TypeError, match="too many positional arguments"):
+        call(func, 1, 2)
+    with pytest.raises(TypeError, match="too many positional arguments"):
+        call(func, 1, 2, c=3)
+
+    def func(a, *, b, **kwargs):
+        return a, b, kwargs
+
+    assert call(func, 1, b=2) == (1, 2, {})
+    assert call(func, 1, b=2, c=3) == (1, 2, {"c": 3})
+    assert call(func, 1, b=2, c=3, d=4) == (1, 2, {"c": 3, "d": 4})
+    assert call(func, a=1, b=2) == (1, 2, {})
+    assert call(func, c=3, a=1, b=2) == (1, 2, {"c": 3})
+    with pytest.raises(TypeError, match="missing a required argument: 'b'"):
+        call(func, a=1)
+    with pytest.raises(TypeError, match="missing a required argument: 'a'"):
+        call(func, c=3, b=2)
+
+
+def test_signature_bind_with_arg_named_self():
+    def test(a, self, b):
+        pass
+
+    sig = Signature.from_callable(test)
+    ba = sig.bind(1, 2, 3)
+    args, _ = sig.unbind(ba)
+    assert args == (1, 2, 3)
+    ba = sig.bind(1, self=2, b=3)
+    args, _ = sig.unbind(ba)
+    assert args == (1, 2, 3)


### PR DESCRIPTION
The objective is to have a more performant `inspect.Signature` implementation especially in regards of binding arguments to parameters. This is going to help to validate both function calls and object initializations.

Even without compilation the added `Signature` class outperforms the stdlib one:
```
---------------------------------------------------------------------------------- benchmark: 2 tests ---------------------------------------------------------------------------------
Name (time in us)        Min                Max              Mean            StdDev            Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_signature        1.1880 (1.0)      13.5914 (1.0)      1.3703 (1.0)      0.5457 (1.0)      1.2643 (1.0)      0.0413 (1.0)      751;1326      729.7579 (1.0)       20000          10
test_inspect          2.0654 (1.74)     16.7978 (1.24)     2.3383 (1.71)     0.6871 (1.26)     2.1622 (1.71)     0.0840 (2.03)     810;3676      427.6570 (0.59)      20000          10
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

After compilation:

```
--------------------------------------------------------------------------------------------- benchmark: 2 tests ---------------------------------------------------------------------------------------------
Name (time in ns)            Min                     Max                  Mean                StdDev                Median                 IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_signature          346.5975 (1.0)        7,967.0979 (1.0)        377.4496 (1.0)        183.3671 (1.0)        363.8997 (1.0)        6.4989 (1.0)      109;1711    2,649.3602 (1.0)       20000          10
test_inspect          2,068.0018 (5.97)     177,226.7016 (22.24)    2,317.2059 (6.14)     1,517.5780 (8.28)     2,196.4021 (6.04)     103.6999 (15.96)    686;1291      431.5542 (0.16)      20000          10
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

Benchmarked via

```py
def func(x: int, y: str, *args: int, z: float = 3.14, **kwargs) -> float: ...


args = (1, "a", 2, 3, 4)
kwargs = dict(z=3.14, w=5, q=6)
expected = {"x": 1, "y": "a", "args": (2, 3, 4), "z": 3.14, "kwargs": {"w": 5, "q": 6}}


def test_inspect(benchmark):
    sig = InspectSignature.from_callable(func)
    r = benchmark.pedantic(
        sig.bind, args=args, kwargs=kwargs, iterations=ITS, rounds=20000
    )
    assert r.arguments == expected


def test_signature(benchmark):
    sig = Signature.from_callable(func)
    r = benchmark.pedantic(
        sig.bind, args=args, kwargs=kwargs, iterations=ITS, rounds=20000
    )
    assert r == expected
```