### PR TITLE
ci: clearing ruff check violations

### DIFF
--- a/koerce/__init__.py
+++ b/koerce/__init__.py
@@ -84,6 +84,8 @@ def koerce(
         The value to match.
     context
         Arbitrary mapping of values to be used while matching.
+    allow_coercion
+        Whether to allow coercion of values to match the pattern.
 
     Returns
     -------

--- a/koerce/__init__.py
+++ b/koerce/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 
-from ._internal import *
+from ._internal import *  # noqa: F403
 
 
 class _Variable(Deferred):

--- a/koerce/_internal.py
+++ b/koerce/_internal.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from .annots import *
-from .builders import *
-from .patterns import *
+from .annots import *  # noqa: F403
+from .builders import *  # noqa: F403
+from .patterns import *  # noqa: F403
 
 compiled = False

--- a/koerce/annots.py
+++ b/koerce/annots.py
@@ -740,7 +740,7 @@ class AnnotableMeta(AbstractMeta):
         else:
             is_initable = initable
         for parent in bases:
-            try:  # noqa: SIM105
+            try:
                 spec = parent.__spec__
             except AttributeError:
                 continue

--- a/koerce/patterns.py
+++ b/koerce/patterns.py
@@ -803,9 +803,9 @@ class AsBool(Pattern):
                 return True
         if isinstance(value, str):
             lowered = value.lower()
-            if lowered == "true" or lowered == "1":
+            if lowered in ["true", "1"]:
                 return True
-            elif lowered == "false" or lowered == "0":
+            elif lowered in ["false", "0"]:
                 return False
         raise MatchError(self, value)
 

--- a/koerce/patterns.py
+++ b/koerce/patterns.py
@@ -2569,6 +2569,10 @@ def pattern(
     obj
         The object to create a pattern from. Can be a pattern, a type, a callable,
         a mapping, an iterable or a value.
+    allow_coercion
+        Whether to allow type coercion during matching.
+    self_qualname
+        The qualified name of the class that is being constructed.
 
     Examples
     --------

--- a/koerce/tests/test_annots.py
+++ b/koerce/tests/test_annots.py
@@ -996,10 +996,7 @@ class List(Annotable, Generic[T]):
             return NotImplemented
         if len(self) != len(other):
             return False
-        for a, b in zip(self, other):
-            if a != b:
-                return False
-        return True
+        return all(a == b for a, b in zip(self, other))
 
 
 # AnnotableMeta doesn't extend ABCMeta, so we need to register the class
@@ -1048,10 +1045,7 @@ class Map(Annotable, Generic[K, V]):
             return NotImplemented
         if len(self) != len(other):
             return False
-        for key in self:
-            if self[key] != other[key]:
-                return False
-        return True
+        return all(self[key] == other[key] for key in self)
 
     def items(self):
         for key in self:

--- a/koerce/tests/test_annots.py
+++ b/koerce/tests/test_annots.py
@@ -9,6 +9,7 @@ from typing import (
     Annotated,
     Any,
     Callable,
+    ClassVar,
     Generic,
     Mapping,
     Optional,
@@ -2174,7 +2175,7 @@ def test_user_model():
         id: int
         name: str = "Jane Doe"
         age: int | None = None
-        children: list[str] = []
+        children: ClassVar[list[str]] = []
 
     assert User.__spec__.initable is False
     assert User.__spec__.immutable is False

--- a/koerce/tests/test_builders.py
+++ b/koerce/tests/test_builders.py
@@ -25,7 +25,6 @@ from koerce._internal import (
     Var,
     builder,
     deferrable,
-    resolve,
 )
 
 _ = Deferred(Var("_"))

--- a/koerce/tests/test_y.py
+++ b/koerce/tests/test_y.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from inspect import Signature as InspectSignature
-from typing import Generic
+from typing import ClassVar, Generic
 
 import pytest
 
@@ -161,21 +161,21 @@ class PUser(BaseModel):
     id: int
     name: str = "Jane Doe"
     age: int | None = None
-    children: list[str] = []
+    children: ClassVar[list[str]] = []
 
 
 class KUser(Annotable):
     id: int
     name: str = "Jane Doe"
     age: int | None = None
-    children: list[str] = []
+    children: ClassVar[list[str]] = []
 
 
 class MUser(msgspec.Struct):
     id: int
     name: str = "Jane Doe"
     age: int | None = None
-    children: list[str] = []
+    children: ClassVar[list[str]] = []
 
 
 data = {"id": 1, "name": "Jane Doe", "age": None, "children": []}

--- a/koerce/utils.py
+++ b/koerce/utils.py
@@ -4,7 +4,7 @@ import itertools
 import sys
 import typing
 from collections.abc import Hashable, Mapping, Sequence, Set
-from typing import Any, ClassVar, ForwardRef, Optional, TypeVar
+from typing import Any, ForwardRef, Optional, TypeVar
 
 from typing_extensions import Self
 


### PR DESCRIPTION
I made some progress on items starting from #14, and more checks are passing now.

There are 17 rule violations remaining, with most of them being in F405 from the star imports. I'm happy to go through and mark those as #noqa: F405 to take care of them, since you mentioned that the star imports were being done for Cython build problems.

Here are the ones that are left:
<details closed>
<summary>Verbose Output</summary>
  
koerce/__init__.py:8:17: F405 `Deferred` may be undefined, or defined from star imports
koerce/__init__.py:10:19: F405 `Var` may be undefined, or defined from star imports
koerce/__init__.py:14:16: F405 `Capture` may be undefined, or defined from star imports
koerce/__init__.py:53:20: F405 `pattern` may be undefined, or defined from star imports
koerce/__init__.py:54:20: F405 `deferred` may be undefined, or defined from star imports
koerce/__init__.py:62:16: F405 `Replace` may be undefined, or defined from star imports
koerce/__init__.py:75:10: F405 `Pattern` may be undefined, or defined from star imports
koerce/__init__.py:75:26: F405 `Any` may be undefined, or defined from star imports
koerce/__init__.py:75:40: F405 `Context` may be undefined, or defined from star imports
koerce/__init__.py:76:6: F405 `Any` may be undefined, or defined from star imports
koerce/__init__.py:109:11: F405 `pattern` may be undefined, or defined from star imports
koerce/__init__.py:112:12: F405 `MatchError` may be undefined, or defined from star imports
koerce/annots.py:841:33: F821 Undefined name `Self`
koerce/tests/test_y.py:13:1: E402 Module level import not at top of file
koerce/tests/test_y.py:14:1: E402 Module level import not at top of file
koerce/tests/test_y.py:15:1: E402 Module level import not at top of file
koerce/tests/test_y.py:17:1: E402 Module level import not at top of file
</details>

I also added the docstrings for `allow_coercion` and `self_qualname` but they may need to be revised a bit. 